### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastai
+diffusers
+transformers
+huggingface-hub


### PR DESCRIPTION
Add a `requirements.txt` file to install the dependencies needed to run the `stable_diffusion.ipynb` file.

Install the `diffusers` library from source because of commit [`92d70863663662669ee3c376909be1f876e00965`](https://github.com/huggingface/diffusers/commit/92d70863663662669ee3c376909be1f876e00965) which is needed for fp16 to work.

Refs huggingface/diffusers#769

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>